### PR TITLE
Set epsilon to 1e-14

### DIFF
--- a/src/Data/Graph/BellmanFord.hs
+++ b/src/Data/Graph/BellmanFord.hs
@@ -84,7 +84,7 @@ data MState s v meta = MState
     }
 
 epsilon :: Double
-epsilon = 1.0e-15
+epsilon = 1.0e-14
 
 -- | Reset state in 'MState' so that it's the same as returned by 'initState'
 resetState


### PR DESCRIPTION
Test file "test/data/run-191120.json" in [`order-graph`](https://github.com/runeksvendsen/order-graph) produces "negative cycle is non-negative"-error when epsilon equals 1e-15.